### PR TITLE
Fix default hint

### DIFF
--- a/load_gen.cc
+++ b/load_gen.cc
@@ -808,7 +808,7 @@ int parse_arguments2(int argc, char *argv[]) {
   args::Group group5(parser, "Optional less frequent switches and parameters:", args::Group::Validators::DontCare);
 */
 
-  args::ValueFlag<long> insert_cmd(group1, "I", "Number of inserts [def: 1]", {'I', "insert"});
+  args::ValueFlag<long> insert_cmd(group1, "I", "Number of inserts [def: 0]", {'I', "insert"});
   args::ValueFlag<long> update_cmd(group1, "U", "Number of updates [def: 0]", {'U', "update"});
   args::ValueFlag<long> point_delete_cmd(group1, "D", "Number of point deletes [def: 0]", {'D', "point_delete"});
   args::ValueFlag<long> range_delete_cmd(group1, "R", "Number of range deletes [def: 0]", {'R', "range_delete"});


### PR DESCRIPTION
According to the code assigning the default value:

https://github.com/BU-DiSC/K-V-Workload-Generator/blob/40551f318b458b269447b4b5b62f173ecbf2b0a0/load_gen.cc#L878-L882

`insert_cmd` has a default value: 0.